### PR TITLE
Android 8.0 Oreo support.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26"
 
     defaultConfig {
         applicationId "caller.alarmist"
         minSdkVersion 21
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 15
         versionName "4.02"
     }

--- a/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
+++ b/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
@@ -47,6 +47,7 @@ public class AlarmClockWatcher extends NotificationListenerService {
     static final int KEY_NEW_ALARM = 2;
     static final String DESK_CLOCK_GOOGLE = "com.google.android.deskclock";
     static final String DESK_CLOCK = "com.android.deskclock";
+    static final String BETTER_ALARM = "com.better.alarm";
     public static final String EXTRA_SETTINGS_BIND = "BINDING_FROM_SETTINGS";
     private static final String TAG = "AlarmistNLS";
     private static final int KEY_WATCH_APP_HAS_STARTED = 7;
@@ -221,7 +222,7 @@ public class AlarmClockWatcher extends NotificationListenerService {
             final String creatorPackage = alarmIntent != null
                     ? alarmIntent.getCreatorPackage()
                     : null;
-            if (creatorPackage != null && (creatorPackage.equals(DESK_CLOCK) || creatorPackage.equals(DESK_CLOCK_GOOGLE))) {
+            if (creatorPackage != null && (creatorPackage.equals(DESK_CLOCK) || creatorPackage.equals(DESK_CLOCK_GOOGLE) || creatorPackage.equals(BETTER_ALARM))) {
                 final long triggerTime = nextClock.getTriggerTime();
 
                 if(alarmByTrigger.containsKey(triggerTime)) {
@@ -268,9 +269,15 @@ public class AlarmClockWatcher extends NotificationListenerService {
                         return AlarmState.UNKNOWN;
                 }
             } else if (notification.actions != null && notification.actions.length > 0) {
+                // Google DeskClock, SNOOZE / DISMISS.
                 if (notification.actions.length == 2
                         && notification.actions[0].title.equals(getString(R.string.alarm_alert_snooze_text))
                         && notification.actions[1].title.equals(getString(R.string.alarm_alert_dismiss_text))) {
+                    return AlarmState.RINGING;
+                // SimpleAlarmClock (com.better.alarm), SNOOZE / RESCHEDULE / DISMISS
+                } else if (notification.actions.length == 3
+                        && notification.actions[0].title.equals(getString(R.string.alarm_alert_snooze_text))
+                        && notification.actions[2].title.equals(getString(R.string.alarm_alert_dismiss_text))) {
                     return AlarmState.RINGING;
                 } else if (notification.actions.length == 1 && notification.actions[0].title.equals(getString(R.string.alarm_alert_dismiss_text))) {
                     return AlarmState.SNOOZED;
@@ -384,7 +391,7 @@ public class AlarmClockWatcher extends NotificationListenerService {
 
         if(!hasRetrievedExistingNotifications) sendingLocked = true;
 
-        if (packageName.equals(DESK_CLOCK) || packageName.equals(DESK_CLOCK_GOOGLE)) {
+        if (packageName.equals(DESK_CLOCK) || packageName.equals(DESK_CLOCK_GOOGLE) || packageName.equals(BETTER_ALARM)) {
             final Notification notification = sbn.getNotification();
             final CharSequence title = notification.extras.getCharSequence(Notification.EXTRA_TITLE);
             final CharSequence message = notification.extras.getCharSequence(Notification.EXTRA_TEXT);
@@ -497,7 +504,7 @@ public class AlarmClockWatcher extends NotificationListenerService {
         }
         if(message == null || title == null) return;
 
-        if (packageName.equals(DESK_CLOCK) || packageName.equals(DESK_CLOCK_GOOGLE)) {
+        if (packageName.equals(DESK_CLOCK) || packageName.equals(DESK_CLOCK_GOOGLE) || packageName.equals(BETTER_ALARM)) {
             AlarmState type = alarmType(notification);
             if(LOGGING)Log.v(TAG, "********** oNR " + type.toString());
             if (type == AlarmState.RINGING) {

--- a/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
+++ b/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
@@ -223,6 +223,7 @@ public class AlarmClockWatcher extends NotificationListenerService {
             if(LOGGING)Log.d(TAG, String.format("Pref changed: %s", key));
             always_notify = sharedPreferences.getBoolean(getString(R.string.pref_key_notif_always), false);
             wait_for_watch_app = sharedPreferences.getBoolean(getString(R.string.pref_key_wait_for_watch_app), true);
+            if (LOGGING) Log.d(TAG, "onSharedPreferenceChanged: always_notify: " + always_notify + " isLocked(): " + isLocked());
         }
     };
     private SharedPreferences sharedPreferences;
@@ -388,6 +389,14 @@ public class AlarmClockWatcher extends NotificationListenerService {
 
         startForeground(NOTIFICATION_SERVICE_ID, notification);
         super.onCreate();
+    }
+
+    public void onListenerConnected() {
+        if (LOGGING) Log.d(TAG, "Alarmist listener connected.");
+    }
+
+    public void onListenerDisconnected() {
+        if (LOGGING) Log.d(TAG, "Alarmist listener disconnected.");
     }
 
     private final IBinder settingsBinder = new SettingsBinder();

--- a/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
+++ b/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.ComponentName;
 import android.os.Binder;
 import android.os.Handler;
 import android.os.IBinder;
@@ -373,6 +374,14 @@ public class AlarmClockWatcher extends NotificationListenerService {
         notify.createNotificationChannel(notify_channel);
         notify.createNotificationChannel(service_notify_channel);
 
+        notification = new Notification.Builder(ctx, ALARMIST_SERVICE_CHANNEL)
+                .setContentTitle("Alarmist")
+                .setContentText("Alarmist notification service.")
+                .setTicker("Alarmist")
+                .setSmallIcon(R.drawable.stat_notify_alarm)
+                .build();
+
+        startForeground(NOTIFICATION_SERVICE_ID, notification);
         super.onCreate();
     }
 

--- a/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
+++ b/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
@@ -4,6 +4,8 @@ import android.app.AlarmManager;
 import android.app.KeyguardManager;
 import android.app.Notification;
 import android.app.PendingIntent;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -35,6 +37,8 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static android.app.NotificationManager.IMPORTANCE_DEFAULT;
+import static android.app.NotificationManager.IMPORTANCE_MIN;
 import static java.util.Calendar.DAY_OF_WEEK;
 
 //See https://android.googlesource.com/platform/packages/apps/DeskClock/+/master/src/com/android/deskclock/alarms/AlarmNotifications.java
@@ -55,8 +59,13 @@ public class AlarmClockWatcher extends NotificationListenerService {
     private static final int KEY_HOUR = 21;
     private static final int KEY_MINUTE = 22;
     private static final int KEY_RECURSION = 23;
+    private static final int NOTIFICATION_SERVICE_ID = 1;
     static final short RECURSION_NONE = 0;
     static final short RECURSION_WEEKLY = 1;
+    static final String ALARMIST_DEFAULT_CHANNEL = "Alarmist Default";
+    static final String ALARMIST_SERVICE_CHANNEL = "Alarmist Service";
+    private NotificationChannel notify_channel = new NotificationChannel (ALARMIST_DEFAULT_CHANNEL, "Alarmist", IMPORTANCE_DEFAULT);
+    private NotificationChannel service_notify_channel = new NotificationChannel (ALARMIST_SERVICE_CHANNEL, "Alarmist Service", IMPORTANCE_MIN);
     private final FinalInt tId = new FinalInt();
     private final PebbleKit.PebbleNackReceiver pebbleNackReceiver = new PebbleKit.PebbleNackReceiver(WATCHAPP_UUID) {
         @Override
@@ -351,6 +360,19 @@ public class AlarmClockWatcher extends NotificationListenerService {
         PebbleKit.registerReceivedNackHandler(this, pebbleNackReceiver);
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         sharedPreferences.registerOnSharedPreferenceChangeListener(preferenceChangeListener);
+
+        final Context ctx = this;
+
+        NotificationManager notify = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        service_notify_channel.enableLights(false);
+        service_notify_channel.enableVibration(false);
+        service_notify_channel.setBypassDnd(false);
+        service_notify_channel.setShowBadge(true);
+        service_notify_channel.setImportance(IMPORTANCE_MIN);
+        notify.createNotificationChannel(notify_channel);
+        notify.createNotificationChannel(service_notify_channel);
+
         super.onCreate();
     }
 

--- a/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
+++ b/app/src/main/java/caller/alarmist/AlarmClockWatcher.java
@@ -362,6 +362,11 @@ public class AlarmClockWatcher extends NotificationListenerService {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         sharedPreferences.registerOnSharedPreferenceChangeListener(preferenceChangeListener);
 
+        always_notify = sharedPreferences.getBoolean(getString(R.string.pref_key_notif_always), false);
+        wait_for_watch_app = sharedPreferences.getBoolean(getString(R.string.pref_key_wait_for_watch_app), false);
+
+        if (LOGGING) Log.d(TAG, "onCreate: always_notify: " + always_notify + " isLocked(): " + isLocked());
+
         final Context ctx = this;
 
         NotificationManager notify = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);

--- a/app/src/main/java/caller/alarmist/RingingAlarm.java
+++ b/app/src/main/java/caller/alarmist/RingingAlarm.java
@@ -154,8 +154,15 @@ public class RingingAlarm {
     }
 
     private PendingIntent getOriginalDismissIntent() {
-        if(type == AlarmType.ALARM)
-            return deskClockNotification.actions[1].actionIntent;
+        if (type == AlarmType.ALARM) {
+	    if (deskClockNotification.actions.length == 3) {
+		// Simple Alarm Clock, has SNOOZE, RESCHEDULE, and DISMISS.
+		return deskClockNotification.actions[2].actionIntent;
+	    } else {
+		// Google DeskClock, has SNOOZE and DISMISS.
+		return deskClockNotification.actions[1].actionIntent;
+	    }
+	}
         // TIMER
         return deskClockNotification.actions[0].actionIntent;
     }

--- a/app/src/main/java/caller/alarmist/RingingAlarm.java
+++ b/app/src/main/java/caller/alarmist/RingingAlarm.java
@@ -106,7 +106,7 @@ public class RingingAlarm {
             final CharSequence contentText = type == AlarmType.ALARM
                     ? ctx.getString(R.string.alarm_ringing_pebble_msg, title, message)
                     : message;
-            final Notification newNotification = new Notification.Builder(ctx)
+            final Notification newNotification = new Notification.Builder(ctx, AlarmClockWatcher.ALARMIST_DEFAULT_CHANNEL)
                     .setContentTitle(title)
                     .setContentText(contentText)
                     .setPriority(Notification.PRIORITY_MIN)

--- a/app/src/main/java/caller/alarmist/SettingsActivity.java
+++ b/app/src/main/java/caller/alarmist/SettingsActivity.java
@@ -95,7 +95,7 @@ public class SettingsActivity extends Activity {
                         @Override
                         public void run() {
                             NotificationManager notify = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
-                            notify.notify(3, new Notification.Builder(ctx)
+                            notify.notify(3, new Notification.Builder(ctx, AlarmClockWatcher.ALARMIST_DEFAULT_CHANNEL)
                                     .setContentTitle("Alarmist test")
                                     .setContentText("Alarmist can send notifications to your Pebble")
                                     .setPriority(Notification.PRIORITY_MAX)

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@
 buildscript {
     repositories {
         jcenter()
+        mavenCentral()
+        maven { url "https://oss.sonatype.org/content/groups/public/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.3'
@@ -15,6 +17,8 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        mavenCentral()
+        maven { url "https://oss.sonatype.org/content/groups/public/" }
     }
 }
 


### PR DESCRIPTION
Alright, so the various commits have decent commit messages, but the basic intent is to work again on Android Oreo.

To pull this off, I had to add support for SimpleAlarmClock (com.better.alarm), create a foreground notification, etc.

(See the commit messages for details.  The short version is that on Android 8, the same version of Clock that works on Android 7 no longer generates notifications during alarms.  This might even be a bug.   The other stuff is just generally needed for Oreo, but SimpleAlarmClock was needed because Clock doesn't make notifications, grr.)

I also bumped the targeted API to 26.  It is possible that things will still work if we dial that back, but I needed some stuff that didn't exist that long ago like notification channels.

This has been tested on my Verizon Pixel XL 128GB running the Oreo release.

Note: You may need to reboot your phone (once) after adding this to get notifications to work right with the service.  I'm not sure if my problem was because I uninstalled the APK with your signing key and installed my own, or if Android has problems when apps change what they need too much.  I have not seen that problem except the very first time, so it's hard to tell.